### PR TITLE
hotfix(global): improve self-hosted docker startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,3 +77,4 @@ FROM base
 USER app:app
 WORKDIR /app
 COPY --from=builder --chown=app:app /app /app
+CMD ["bash", "-lc", "yarn workspace @app/condo start"]

--- a/apps/condo/domains/news/components/FilesUploadList/utils/fileConversion.ts
+++ b/apps/condo/domains/news/components/FilesUploadList/utils/fileConversion.ts
@@ -215,9 +215,10 @@ export const convertFile = async (file: File, onProgress?: UploadRequestOption['
 
             let filename = file.name
             if (file.type === 'video/quicktime') filename = file.name.replace(/\.mov$/i, '.mp4')
+            const arrayBuffer = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer
 
             return new File(
-                [data],
+                [arrayBuffer],
                 filename,
                 { type: 'video/mp4' }
             )

--- a/apps/condo/pages/tour/guide.tsx
+++ b/apps/condo/pages/tour/guide.tsx
@@ -44,9 +44,9 @@ const getTextWithAccent = (text: string) => {
 
     return parts.map((part, index) => {
         if (index % 2 === 0) {
-            return <Typography.Text type='secondary'>{part}</Typography.Text>
+            return <Typography.Text key={index} type='secondary'>{part}</Typography.Text>
         } else {
-            return <Typography.Text type='primary'>{part}</Typography.Text>
+            return <Typography.Text key={index} type='primary'>{part}</Typography.Text>
         }
     })
 }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "stylelint-config-rational-order": "^0.1.2",
     "stylelint-config-standard": "^28.0.0",
     "turbo": "^2.4.4",
-    "typescript": "^5.8.3"
+    "typescript": "5.8.3"
   },
   "engines": {
     "node": ">=24",

--- a/packages/codegen/generate.hooks.ts
+++ b/packages/codegen/generate.hooks.ts
@@ -327,7 +327,7 @@ export function generateReactHooks<
 
         const count = (data && data.meta) ? data.meta.count : null
         const typedRefetch: IRefetchType<GQLObject, QueryVariables> = refetch
-        const typedFetchMore: IFetchMoreType<GQLObject, QueryVariables> = fetchMore
+        const typedFetchMore = fetchMore as unknown as IFetchMoreType<GQLObject, QueryVariables>
         const typedStopPolling: IStopPollingType = stopPolling
 
         let readableError
@@ -362,7 +362,7 @@ export function generateReactHooks<
         const objs: GQLObject[] = useMemo(() => (data && data.objs) ? data.objs.filter(nonNull) : [], [data])
         const count = (data && data.meta) ? data.meta.count : null
         const typedRefetch: IRefetchType<GQLObject, QueryVariables> = refetch
-        const typedFetchMore: IFetchMoreType<GQLObject, QueryVariables> = fetchMore
+        const typedFetchMore = fetchMore as unknown as IFetchMoreType<GQLObject, QueryVariables>
         const typedStopPolling: IStopPollingType = stopPolling
 
         let readableError

--- a/packages/files/src/client.ts
+++ b/packages/files/src/client.ts
@@ -161,13 +161,15 @@ export async function upload ({ serverUrl, files, meta, attach }: UploadOptions)
         if (typeof Blob !== 'undefined' && f instanceof Blob) {
             form.append('file', f, filename)
         } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(f)) {
-            const blob = new Blob([f], { type: 'application/octet-stream' })
+            const arrayBuffer = f.buffer.slice(f.byteOffset, f.byteOffset + f.byteLength) as ArrayBuffer
+            const blob = new Blob([arrayBuffer], { type: 'application/octet-stream' })
             form.append('file', blob, filename)
         } else if (f && typeof f === 'object' && 'buffer' in f) {
             const { buffer, filename: fn } = f as { buffer: Buffer, filename?: string }
+            const arrayBuffer = buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength) as ArrayBuffer
             const file = typeof File !== 'undefined'
-                ? new File([buffer], fn ?? filename, { type: 'application/octet-stream' })
-                : new Blob([buffer], { type: 'application/octet-stream' })
+                ? new File([arrayBuffer], fn ?? filename, { type: 'application/octet-stream' })
+                : new Blob([arrayBuffer], { type: 'application/octet-stream' })
             form.append('file', file as any, fn ?? filename)
         } else {
             throw new TypeError('Unsupported file type for append')


### PR DESCRIPTION
I hit these while getting a self-hosted/Dokku deployment running from this repository. They are small fixes, but together they remove a few rough edges from the default Docker path and file upload flow.

The Docker image now has an explicit default command for the Condo app, so a built image can start without passing the command manually. File uploads now pass ArrayBuffer slices into File/Blob when the source is a Node Buffer or converted media buffer; that avoids leaking the full backing buffer into the upload payload. I also pinned the TypeScript compiler version used by the workspace, kept generated `fetchMore` typing compatible with the current Apollo types, and added keys to the tour guide text fragments to avoid React list warnings.

I checked this with:

- `git diff --check upstream/main...HEAD`
- `yarn eslint packages/files/src/client.ts packages/codegen/generate.hooks.ts apps/condo/domains/news/components/FilesUploadList/utils/fileConversion.ts apps/condo/pages/tour/guide.tsx` (no errors, existing warnings only)
- `yarn tsc -p packages/files/tsconfig.json --noEmit`

I also tried `yarn workspace @open-condo/files build`, but this checkout has root-owned files in `packages/files/dist`, so `rimraf dist` fails with `EACCES` before TypeScript runs. The no-emit TypeScript check above covers the changed `@open-condo/files` source.

By opening this PR I agree to the contributor license terms in `docs/contributing.md`.
